### PR TITLE
Hotfix/industry comp table

### DIFF
--- a/app/components/graphbuilder-table.js
+++ b/app/components/graphbuilder-table.js
@@ -234,7 +234,7 @@ export default EmberTableComponent.extend({
       textAlign: colSettings.type === 'int' ? 'text-align-right' : 'text-align-left',
       headerCellName: column.copy ? `graph_builder.table.${column.copy}`: `graph_builder.table.${column.key}`,
       getCellContent: this.generateCellContent(column),
-      isResizable: false,
+      isResizable: true,
       savedWidth: colSettings.savedWidth ? colSettings.savedWidth : 160,
       key: column.key
     });

--- a/app/styles/components/_modules/_ember-table.scss
+++ b/app/styles/components/_modules/_ember-table.scss
@@ -13,7 +13,6 @@
   background: $colorBrown300;
   border: none;
   margin-bottom: $baseSpace / 2;
-  overflow: initial;
 }
 
 .ember-table-header-row, .ember-table-header-container .ember-table-table-fixed-wrapper {


### PR DESCRIPTION
<img width="1058" alt="screen shot 2015-09-03 at 9 24 17 am" src="https://cloud.githubusercontent.com/assets/2522945/9659325/dec4b99c-521d-11e5-945a-6ed8ba2195d8.png">
Resize column removes a class and allows overflow.  Solution I had is remove resizing.
