### PR TITLE
Export btn fixes

### DIFF
--- a/app/styles/components/_components/_button.scss
+++ b/app/styles/components/_components/_button.scss
@@ -64,3 +64,7 @@ button::-moz-focus-inner {
   align-items: center;
   margin-bottom: $baseSpace / 2;
 }
+
+.btn--text {
+  text-align: right;
+}

--- a/app/styles/components/_modules/_ctas.scss
+++ b/app/styles/components/_modules/_ctas.scss
@@ -8,6 +8,11 @@
   position: absolute;
   top: 0;
   left: -5rem - $baseSpace;
+
+}
+
+.cta__wrap__right {
+  	text-align: right;
 }
 
 // .ctas {

--- a/app/styles/components/_modules/_ctas.scss
+++ b/app/styles/components/_modules/_ctas.scss
@@ -8,10 +8,9 @@
   position: absolute;
   top: 0;
   left: -5rem - $baseSpace;
-
 }
 
-.cta__wrap__right {
+.cta__wrap--right {
   	text-align: right;
 }
 

--- a/app/templates/components/table-download.hbs
+++ b/app/templates/components/table-download.hbs
@@ -1,6 +1,7 @@
-<aside class="cta__wrap">
-  <a class="btn btn--standalone btn--stream btn--cta" {{action 'save'}}>
+<aside class="cta__wrap__right">
+  <a class="btn btn--standalone btn--text" {{action 'save'}}>
     {{fa-icon "download" classNames="cta__icon"}}
+    Export data
   </a>
 </aside>
 

--- a/app/templates/components/table-download.hbs
+++ b/app/templates/components/table-download.hbs
@@ -1,4 +1,4 @@
-<aside class="cta__wrap__right">
+<aside class="cta__wrap--right">
   <a class="btn btn--standalone btn--text" {{action 'save'}}>
     {{fa-icon "download" classNames="cta__icon"}}
     Export data

--- a/app/templates/components/table-download.hbs
+++ b/app/templates/components/table-download.hbs
@@ -4,4 +4,3 @@
     Export data
   </a>
 </aside>
-

--- a/app/templates/visualization.hbs
+++ b/app/templates/visualization.hbs
@@ -58,15 +58,15 @@
       text=visualizationExplanation
     }}
     <div class="ember__table__wrap">
+      {{component 'table-download'
+        name=builderModHeader
+        data=immutableData
+        search=search
+      }}
       {{component 'graphbuilder-table'
         data=filteredData
         source=source
         isSingleYear=isSingleYear
-        search=search
-      }}
-      {{component 'table-download'
-        name=builderModHeader
-        data=immutableData
         search=search
       }}
     </div>


### PR DESCRIPTION
Now against beta instead of master — pulls Export icon button out from the left margin of data table and places it above / right.