### PR TITLE
add min height to headers for sections stream

### DIFF
--- a/app/styles/components/_modules/_stream-section.scss
+++ b/app/styles/components/_modules/_stream-section.scss
@@ -34,6 +34,7 @@
 }
 
 .section__subhead {
+  min-height: 1.75 * $baseSpace;
   margin-bottom: $baseSpace;
   line-height: 120%;
 }


### PR DESCRIPTION
bug fix for section header when copy is too long 

Bug
<img width="1068" alt="screen shot 2015-10-29 at 4 44 13 pm" src="https://cloud.githubusercontent.com/assets/2522945/10831501/63f12294-7e5c-11e5-9736-5402708303a0.png">

The Fix
<img width="1124" alt="screen shot 2015-10-29 at 4 46 25 pm" src="https://cloud.githubusercontent.com/assets/2522945/10831550/b4464dfa-7e5c-11e5-9770-93f93b780fe5.png">
