### PR TITLE
MEX-88 update styling for links in table footers and glossary content

### DIFF
--- a/app/styles/components/_components/_link.scss
+++ b/app/styles/components/_components/_link.scss
@@ -11,7 +11,7 @@ a {
 .link--stream {
   color: $colorGrayDark;
   font-family: $sans;
-  font-weight: 300;
+  font-weight: 600;
   font-size: $fontBase-decrement; // A bit smaller to make x-heights match Plantin's
   &:hover, &:focus, &:active {
     color: $colorBlack;

--- a/app/styles/components/_components/_table.scss
+++ b/app/styles/components/_components/_table.scss
@@ -56,6 +56,7 @@
 
 .table__footer__link--glossary {
   text-transform: lowercase;
+  font-weight: 900;
 }
 
 


### PR DESCRIPTION
Links stand out from their surrounding content in table footers and glossary.