### PR TITLE
Fixed x, y, and r domain values for scatterplots

### DIFF
--- a/app/components/vistk-scatterplot.js
+++ b/app/components/vistk-scatterplot.js
@@ -33,6 +33,9 @@ export default Ember.Component.extend({
       var_r: this.get('varSize'),
       radius_min: 2,
       radius_max: 10,
+      x_domain: this.get('x_domain'),
+      y_domain: this.get('y_domain'),
+      r_domain: this.get('r_domain'),
       x_format: format,
       y_format: format,
       duration: 0,
@@ -178,6 +181,10 @@ export default Ember.Component.extend({
       if(this.get('dataType') === 'products' && datum) {
         this.set('eciValue', get(datum, 'eci'));
       }
+
+      this.set('x_domain', vistk.utils.extent(this.get('immutableData'), 'distance'));
+      this.set('y_domain', vistk.utils.extent(this.get('immutableData'), 'complexity'));
+      this.set('r_domain', vistk.utils.extent(this.get('immutableData'), this.get('varSize')));
 
       d3.select(this.get('id')).call(this.get('scatter'));
     });


### PR DESCRIPTION
* Calculates X/Y/Radius data domain on immutable dataset
* Then uses those domains or all scatterplot configurations: filter, RCA selection, time change

Before (using text filter) for http://atlas-colombia-harvard.cid-labs.com/#/location/41/source/products/visualization/scatter/opportunity?endDate=2009&search=text&startDate=2009

<img width="922" alt="screen shot 2016-02-22 at 4 55 57 pm" src="https://cloud.githubusercontent.com/assets/586236/13223683/978aa0c4-d985-11e5-8dda-fd41da20c7d8.png">

After (using text filter)

<img width="919" alt="screen shot 2016-02-22 at 4 55 44 pm" src="https://cloud.githubusercontent.com/assets/586236/13223697/a98273b0-d985-11e5-8e34-8ad8f9409694.png">
