### PR TITLE
[Merged in beta] Make sidenav more visible by default PERU-99

### DIFF
--- a/app/styles/components/_modules/_side-nav.scss
+++ b/app/styles/components/_modules/_side-nav.scss
@@ -24,7 +24,7 @@
   font-size: $fontSmall;
   display: block;
   font-family: $sans;
-  font-weight: 300;
+  font-weight: 400;
   &:hover {
     color: $colorGrayLight;
   }
@@ -32,4 +32,5 @@
 
 .side-nav__item--active {
   color: $colorGrayDark;
+  font-weight: 600;
 }

--- a/app/styles/components/_modules/_side-nav.scss
+++ b/app/styles/components/_modules/_side-nav.scss
@@ -20,7 +20,7 @@
 
 .side-nav__item__link {
   transition: color $animationTime $animationEasing;
-  color: $colorGrayLighter;
+  color: $colorGray;
   font-size: $fontSmall;
   display: block;
   font-family: $sans;


### PR DESCRIPTION
before:

![screen shot 2016-03-29 at 6 00 02 pm](https://cloud.githubusercontent.com/assets/161965/14125281/5683eac6-f5d8-11e5-9416-c69be6837b20.png)

after:

![screen shot 2016-03-29 at 5 59 58 pm](https://cloud.githubusercontent.com/assets/161965/14125284/616fea66-f5d8-11e5-92e5-d8e8fa6b8823.png)

Any darker grabs too much attention, I think.