### PR TITLE
Make real gdp show up in home page PERU-143

### DIFF
--- a/app/templates/location/-country-dotplots.hbs
+++ b/app/templates/location/-country-dotplots.hbs
@@ -22,7 +22,7 @@
         {{vistk-dotplot
           elementId='dotplot--gdp-pc'
           data=dotplotData
-          varX='gdp_pc_nominal'
+          varX='gdp_pc_real'
           varText='name'
           varId='department_id'
           currentSelection=locationId
@@ -40,7 +40,7 @@
         {{vistk-dotplot
           elementId='dotplot--gdp'
           data=dotplotData
-          varX='gdp_nominal'
+          varX='gdp_real'
           varText='name'
           varId='department_id'
         }}


### PR DESCRIPTION
One pitfall is that without the peru locale updates branch the census_year is set to 2010 so make sure you set it  to 2014 as you review the ticket.

Basically the lima dotplot, rankings and country dotplot should have the same values for the same data points